### PR TITLE
Upgrade Lodash & Fix Breaking Changes

### DIFF
--- a/meteor-match.js
+++ b/meteor-match.js
@@ -377,7 +377,7 @@ var _jsKeywords = ["do", "if", "in", "for", "let", "new", "try", "var", "case",
 var _prependPath = function (key, base) {
   if ((typeof key) === "number" || key.match(/^[0-9]+$/))
     key = "[" + key + "]";
-  else if (!key.match(/^[a-z_$][0-9a-z_$]*$/i) || _.contains(_jsKeywords, key))
+  else if (!key.match(/^[a-z_$][0-9a-z_$]*$/i) || _.includes(_jsKeywords, key))
     key = JSON.stringify([key]);
 
   if (base && base[0] !== "[")

--- a/mongo-object.js
+++ b/mongo-object.js
@@ -118,7 +118,7 @@ var MongoObject = function(objOrModifier, blackBoxKeys) {
       affectedKeyGeneric = makeGeneric(affectedKey);
 
       // Determine whether affected key should be treated as a black box
-      affectedKeyIsBlackBox = _.contains(blackBoxKeys, affectedKeyGeneric);
+      affectedKeyIsBlackBox = _.includes(blackBoxKeys, affectedKeyGeneric);
 
       // Mark that this position affects this generic and non-generic key
       if (currentPosition) {
@@ -204,7 +204,7 @@ var MongoObject = function(objOrModifier, blackBoxKeys) {
 
     var updatedValues = {};
     _.each(self._affectedKeys, function(affectedKey, position) {
-      if (options.endPointsOnly && _.contains(self._parentPositions, position)) {
+      if (options.endPointsOnly && _.includes(self._parentPositions, position)) {
         return; //only endpoints
       }
       func.call({
@@ -443,7 +443,7 @@ var MongoObject = function(objOrModifier, blackBoxKeys) {
   self.removeGenericKeys = function(keys) {
     for (var position in self._genericAffectedKeys) {
       if (self._genericAffectedKeys.hasOwnProperty(position)) {
-        if (_.contains(keys, self._genericAffectedKeys[position])) {
+        if (_.includes(keys, self._genericAffectedKeys[position])) {
           self.removeValueForPosition(position);
         }
       }
@@ -512,7 +512,7 @@ var MongoObject = function(objOrModifier, blackBoxKeys) {
     for (var position in self._genericAffectedKeys) {
       if (self._genericAffectedKeys.hasOwnProperty(position)) {
         gk = self._genericAffectedKeys[position];
-        if (!_.contains(checkedKeys, gk)) {
+        if (!_.includes(checkedKeys, gk)) {
           checkedKeys.push(gk);
           if (gk && !test(gk)) {
             keysToRemove.push(gk);
@@ -600,8 +600,8 @@ var MongoObject = function(objOrModifier, blackBoxKeys) {
     var newObj = {};
     _.each(self._affectedKeys, function(affectedKey, position) {
       if (typeof affectedKey === "string" &&
-        (options.keepArrays === true && !_.contains(self._positionsInsideArrays, position) && !_.contains(self._objectPositions, position)) ||
-        (!options.keepArrays && !_.contains(self._parentPositions, position))
+        (options.keepArrays === true && !_.includes(self._positionsInsideArrays, position) && !_.includes(self._objectPositions, position)) ||
+        (!options.keepArrays && !_.includes(self._parentPositions, position))
         ) {
         newObj[affectedKey] = self.getValueForPosition(position);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,302 @@
+{
+  "name": "node-simple-schema",
+  "version": "0.0.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-simple-schema",
+      "version": "0.0.4",
+      "license": "ISC",
+      "dependencies": {
+        "ejson": "^2.1.1",
+        "lodash": "^4.17.21",
+        "string": "^3.3.1"
+      },
+      "devDependencies": {
+        "chai": "^3.2.0",
+        "mocha": "^2.3.2"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha512-CD452fnk0jQyk3NfnK+KkR/hUPoHt5pVaKHogtyyv3N0U4QfAal9W0/rXLOg/vVZgQKa7jdtXypKs1YAip11uQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-eql/node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ejson": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/ejson/-/ejson-2.2.3.tgz",
+      "integrity": "sha512-hsFvJp6OpGxFRQfBR3PSxFpaPALdHDY+SB3TRbMpLWNhvu8GzLiZutof5+/DFd2QekZo3KyXau75ngdJqQUSrw==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+      "dev": true,
+      "dependencies": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "bin": {
+        "jade": "bin/jade"
+      }
+    },
+    "node_modules/jade/node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/jade/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha512-jNt2iEk9FPmZLzL+sm4FNyOIDYXf2wUU6L4Cc8OIKK/kzgMHKPi4YhTZqG4bW4kQVdIv6wutDybRhXfdnujA1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg==",
+      "dev": true
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/string": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
+      "integrity": "sha512-LbvprpPZT/39QKfNrlPX9vXtS7If80vqbPQ7clnHQb5oVOM5hz/cs3iQCCZjvQDwsAWl+HpLQX3gRgN6IC8t3g==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha512-mS5xsnjTh5b7f2DM6bch6lR582UCOTphzINlZnDsfpIRrwI6r58rb6YSSGsdexkm8qw2bBVO2ID2fnJOTuLiPA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "supports-color": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha512-oeHLgfWA7d0CPQa6h0+i5DAJZISz5un0d5SHPkw+Untclcvzv9T+AC3CvGXlZJdOlIbxbTfyyzlqCXc5hjpXYg==",
+      "deprecated": "to-iso-string has been deprecated, use @segment/to-iso-string instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/yourcelf/node-simple-schema",
   "dependencies": {
     "ejson": "^2.1.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.21",
     "string": "^3.3.1"
   },
   "devDependencies": {

--- a/simple-schema-context.js
+++ b/simple-schema-context.js
@@ -54,13 +54,13 @@ SimpleSchemaValidationContext.prototype.validate = function simpleSchemaValidati
 
   //note any currently invalid keys so that we can mark them as changed
   //due to new validation (they may be valid now, or invalid in a different way)
-  var removedKeys = _.pluck(self._invalidKeys, "name");
+  var removedKeys = _.map(self._invalidKeys, "name");
 
   //update
   self._invalidKeys = invalidKeys;
 
   //add newly invalid keys to changedKeys
-  var addedKeys = _.pluck(self._invalidKeys, "name");
+  var addedKeys = _.map(self._invalidKeys, "name");
 
   //mark all changed keys as changed
   var changedKeys = _.union(addedKeys, removedKeys);
@@ -114,7 +114,7 @@ SimpleSchemaValidationContext.prototype.validateOne = function simpleSchemaValid
 //reset the invalidKeys array
 SimpleSchemaValidationContext.prototype.resetValidation = function simpleSchemaValidationContextResetValidation() {
   var self = this;
-  var removedKeys = _.pluck(self._invalidKeys, "name");
+  var removedKeys = _.map(self._invalidKeys, "name");
   self._invalidKeys = [];
   self._markKeysChanged(removedKeys);
 };
@@ -169,9 +169,9 @@ SimpleSchemaValidationContext.prototype._getInvalidKeyObject = function simpleSc
   var SimpleSchema = require("./simple-schema");
   genericName = genericName || SimpleSchema._makeGeneric(name);
 
-  var errorObj = _.findWhere(self._invalidKeys, {name: name});
+  var errorObj = _.find(self._invalidKeys, {name: name});
   if (!errorObj) {
-    errorObj = _.findWhere(self._invalidKeys, {name: genericName});
+    errorObj = _.find(self._invalidKeys, {name: genericName});
   }
   return errorObj;
 };

--- a/simple-schema-utility.js
+++ b/simple-schema-utility.js
@@ -13,7 +13,7 @@ var Utility = {
     if (key === "$pushAll") {
       throw new Error("$pushAll is not supported; use $push + $each");
     }
-    return !_.contains(["$pull", "$pullAll", "$pop", "$slice"], key);
+    return  !_.includes(["$pull", "$pullAll", "$pop", "$slice"], key);
   },
   errorObject: function errorObject(errorType, keyName, keyValue) {
     return {name: keyName, type: errorType, value: keyValue};

--- a/simple-schema-validation-new.js
+++ b/simple-schema-validation-new.js
@@ -169,7 +169,7 @@ var doValidation2 = function doValidation2(obj, isModifier, isUpsert, keyToValid
       }
 
       // Check value against allowedValues array
-      if (def.allowedValues && !_.contains(def.allowedValues, val)) {
+      if (def.allowedValues && !_.includes(def.allowedValues, val)) {
         invalidKeys.push(Utility.errorObject("notAllowed", affectedKey, val, def, ss));
         return;
       }
@@ -283,7 +283,7 @@ var doValidation2 = function doValidation2(obj, isModifier, isUpsert, keyToValid
   // Make sure there is only one error per fieldName
   var addedFieldNames = [];
   invalidKeys = _.filter(invalidKeys, function(errObj) {
-    if (!_.contains(addedFieldNames, errObj.name)) {
+    if (!_.includes(addedFieldNames, errObj.name)) {
       addedFieldNames.push(errObj.name);
       return true;
     }

--- a/simple-schema-validation.js
+++ b/simple-schema-validation.js
@@ -159,7 +159,7 @@ var doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValid
       }
 
       // Check value against allowedValues array
-      if (def.allowedValues && !_.contains(def.allowedValues, val)) {
+      if (def.allowedValues && !_.includes(def.allowedValues, val)) {
         invalidKeys.push(Utility.errorObject("notAllowed", affectedKey, val, def, ss));
         return;
       }
@@ -303,7 +303,7 @@ var doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValid
         if (isUpsert && op === "$set") {
           var presentKeys = _.keys(opObj);
           _.each(ss.objectKeys(), function (schemaKey) {
-            if (!_.contains(presentKeys, schemaKey)) {
+            if (!_.includes(presentKeys, schemaKey)) {
               checkObj(void 0, schemaKey, op, setKeys);
             }
           });
@@ -332,7 +332,7 @@ var doValidation1 = function doValidation1(obj, isModifier, isUpsert, keyToValid
   // Make sure there is only one error per fieldName
   var addedFieldNames = [];
   invalidKeys = _.filter(invalidKeys, function(errObj) {
-    if (!_.contains(addedFieldNames, errObj.name)) {
+    if (!_.includes(addedFieldNames, errObj.name)) {
       addedFieldNames.push(errObj.name);
       return true;
     }

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -322,7 +322,7 @@ function getAutoValues(mDoc, isModifier, extendedAutoValueContext) {
   function runAV(func) {
     var affectedKey = this.key;
     // If already called for this key, skip it
-    if (_.contains(doneKeys, affectedKey)) {
+    if (_.includes(doneKeys, affectedKey)) {
       return;
     }
     var lastDot = affectedKey.lastIndexOf('.');
@@ -514,7 +514,7 @@ var SimpleSchema = function(schemas, options) {
       self._blackboxKeys.push(fieldName);
     }
 
-    if (!_.contains(firstLevelSchemaKeys, fieldNameRoot)) {
+    if (!_.includes(firstLevelSchemaKeys, fieldNameRoot)) {
       firstLevelSchemaKeys.push(fieldNameRoot);
     }
   });
@@ -1021,9 +1021,9 @@ SimpleSchema.prototype.messageForError = function(type, key, def, value) {
 
     // If not, see if there's a default message defined
     if (!msgObj) {
-      msgObj = _.findWhere(message, {exp: null});
+      msgObj = _.find(message, {exp: null});
       if (!msgObj) {
-        msgObj = _.findWhere(message, {exp: void 0});
+        msgObj = _.find(message, {exp: void 0});
       }
     }
 
@@ -1109,7 +1109,7 @@ SimpleSchema.prototype.allowsKey = function(key) {
   var self = this;
 
   // Loop through all keys in the schema
-  return _.any(self._schemaKeys, function(schemaKey) {
+  return _.some(self._schemaKeys, function(schemaKey) {
 
     // If the schema key is the test key, it's allowed.
     if (schemaKey === key) {


### PR DESCRIPTION
In v4.0.0, Lodash updated and deprecated a host of methods. I ran the unit tests in this repo which did a good job of pointing out which Lodash methods needed to be updated.

Changes:

- Upgrade lodash to v4.17.21
- Updated a handful of deprecated/renamed methods